### PR TITLE
:arrow_down: Updated dependencies

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -128,16 +128,16 @@ dependencies {
     implementation 'com.google.android.play:core-ktx:1.8.1'
 
     // Android Jetpack
-    def jetpack_work_version = "2.5.0"
+    def jetpack_work_version = "2.6.0-alpha01"
     implementation "androidx.work:work-runtime-ktx:$jetpack_work_version"
     implementation "androidx.work:work-gcm:$jetpack_work_version"
     androidTestImplementation "androidx.work:work-testing:$jetpack_work_version"
     implementation "androidx.startup:startup-runtime:1.0.0"
 
-    def camerax_version = "1.1.0-alpha02"
+    def camerax_version = "1.1.0-alpha03"
     implementation "androidx.camera:camera-camera2:$camerax_version"
     implementation "androidx.camera:camera-lifecycle:$camerax_version"
-    implementation "androidx.camera:camera-view:1.0.0-alpha22"
+    implementation "androidx.camera:camera-view:1.0.0-alpha23"
 
     // MapBox SDK
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.1'


### PR DESCRIPTION
* `androidx.work:work-runtime-ktx` to `2.6.0-alpha01`
* `androidx.work:work-gcm` to `2.6.0-alpha01`
* `androidx.work:work-testing` to `2.6.0-alpha01`
* `androidx.camera:camera-camera2` to `1.1.0-alpha02`
* `androidx.camera:camera-lifecycle` to `1.1.0-alpha02`
* `androidx.camera:camera-view` to `1.0.0-alpha22`

Signed-off-by: Arnau Mora <arnyminer.z@gmail.com>