### PR TITLE
:arrow_up: Updated dependencies

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     implementation 'com.google.android.play:core-ktx:1.8.1'
 
     // Android Jetpack
-    def jetpack_work_version = "2.6.0-alpha03"
+    def jetpack_work_version = "2.6.0-alpha02"
     implementation "androidx.work:work-runtime-ktx:$jetpack_work_version"
     implementation "androidx.work:work-gcm:$jetpack_work_version"
     androidTestImplementation "androidx.work:work-testing:$jetpack_work_version"

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -127,14 +127,14 @@ dependencies {
     implementation 'com.google.android.play:core-ktx:1.8.1'
 
     // Android Jetpack
-    def jetpack_work_version = "2.6.0-alpha02"
+    def jetpack_work_version = "2.6.0-alpha03"
     implementation "androidx.work:work-runtime-ktx:$jetpack_work_version"
     implementation "androidx.work:work-gcm:$jetpack_work_version"
     androidTestImplementation "androidx.work:work-testing:$jetpack_work_version"
     implementation "androidx.startup:startup-runtime:1.0.0"
 
     // Google Firebase
-    implementation platform('com.google.firebase:firebase-bom:27.1.0')
+    implementation platform('com.google.firebase:firebase-bom:28.0.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-firestore-ktx'
     implementation 'com.google.firebase:firebase-storage-ktx'
@@ -144,7 +144,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-dynamic-links-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-messaging-ktx'
-    implementation 'com.google.firebase:firebase-messaging-directboot:21.1.0'
+    implementation 'com.google.firebase:firebase-messaging-directboot:22.0.0'
 
     // MapBox SDK
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.6.1'


### PR DESCRIPTION
* `androidx.work:work-runtime-ktx` to `2.6.0-alpha03`
* `androidx.work:work-gcm` to `2.6.0-alpha03`
* `androidx.work:work-testing` to `2.6.0-alpha03`
* `com.google.firebase:firebase-bom` to `28.0.0`
* `com.google.firebase:firebase-messaging-directboot` to `22.0.0`

Signed-off-by: Arnau Mora <arnyminer.z@gmail.com>