### PR TITLE
Revert "⬆️ Bump kotlin-gradle-plugin from 1.5.30 to 1.5.31"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         // Build tools
         classpath 'com.android.tools.build:gradle:7.1.0-alpha12'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30'
 
         // Google Services
         classpath 'com.google.gms:google-services:4.3.10'


### PR DESCRIPTION
Reverts Escalar-Alcoia-i-Comtat/Android#373 since incompatible with Compose