### PR TITLE
Revert "⬆️ Bump kotlin-gradle-plugin from 1.5.31 to 1.6.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         // Build tools
         classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31'
 
         // Google Services
         classpath 'com.google.gms:google-services:4.3.10'


### PR DESCRIPTION
Reverts Escalar-Alcoia-i-Comtat/Android#447 since 1.6.0 is incompatible with the Kotlin compiler.