### PR TITLE
Revert "⬆️ Bump kotlin-stdlib-jdk7 from 1.5.31 to 1.6.0"

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -149,7 +149,7 @@ static def getDate() {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31'
 
     // AndroidX dependencies
     implementation 'androidx.appcompat:appcompat:1.4.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -54,7 +54,7 @@ tasks.named("dokkaHtmlPartial") {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.5.0-beta01'


### PR DESCRIPTION
Reverts Escalar-Alcoia-i-Comtat/Android#448 since 1.6.0 is incompatible with the Kotlin compiler.