### PR TITLE
:sparkles: Added `TimberInitializer`

### DIFF
--- a/base/src/main/java/com/arnyminerz/escalaralcoiaicomtat/worker/startup/NotificationChannelsInitializer.kt
+++ b/base/src/main/java/com/arnyminerz/escalaralcoiaicomtat/worker/startup/NotificationChannelsInitializer.kt
@@ -17,5 +17,6 @@ class NotificationChannelsInitializer : Initializer<Boolean> {
             false
         }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+    override fun dependencies(): List<Class<out Initializer<*>>> =
+        listOf(TimberInitializer::class.java)
 }


### PR DESCRIPTION
Fixes Lint build errors