### PR TITLE
✨ Added Semantic Versioning check for expected server version

### DIFF
--- a/base/src/main/java/com/arnyminerz/escalaralcoiaicomtat/activity/MainActivity.kt
+++ b/base/src/main/java/com/arnyminerz/escalaralcoiaicomtat/activity/MainActivity.kt
@@ -154,6 +154,12 @@ class MainActivity : AppCompatActivity() {
                         )
                     }
                 },
+                title = {
+                    Text(stringResource(R.string.dialog_server_version_title))
+                },
+                text = {
+                    Text(stringResource(R.string.dialog_server_version_message))
+                }
             )
 
         Scaffold(

--- a/base/src/main/java/com/arnyminerz/escalaralcoiaicomtat/ui/screen/main/Settings.kt
+++ b/base/src/main/java/com/arnyminerz/escalaralcoiaicomtat/ui/screen/main/Settings.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ChevronLeft
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +29,7 @@ import androidx.navigation.compose.rememberNavController
 import com.arnyminerz.escalaralcoiaicomtat.BuildConfig
 import com.arnyminerz.escalaralcoiaicomtat.R
 import com.arnyminerz.escalaralcoiaicomtat.activity.MainActivity
+import com.arnyminerz.escalaralcoiaicomtat.core.data.SemVer
 import com.arnyminerz.escalaralcoiaicomtat.core.preferences.PreferencesModule
 import com.arnyminerz.escalaralcoiaicomtat.core.ui.isolated_screen.ApplicationInfoWindow
 import com.arnyminerz.escalaralcoiaicomtat.ui.screen.settings.GeneralSettingsScreen
@@ -41,6 +43,7 @@ import com.arnyminerz.escalaralcoiaicomtat.ui.screen.settings.NotificationsSetti
  */
 @Preview(name = "Settings screen")
 @Composable
+@ExperimentalMaterial3Api
 fun MainActivity.SettingsScreen() {
     val settingsNavController = rememberNavController()
     Column(
@@ -102,7 +105,7 @@ fun MainActivity.SettingsScreen() {
                     appName = stringResource(R.string.app_name),
                     appBuild = BuildConfig.VERSION_CODE,
                     appVersion = BuildConfig.VERSION_NAME,
-                    serverVersion = serverVersion,
+                    serverVersion = SemVer.fromString(serverVersion),
                     serverProduction = serverIsProduction,
                     "https://github.com/Escalar-Alcoia-i-Comtat/Android",
                 )

--- a/core/src/main/java/com/arnyminerz/escalaralcoiaicomtat/core/data/SemVer.kt
+++ b/core/src/main/java/com/arnyminerz/escalaralcoiaicomtat/core/data/SemVer.kt
@@ -1,0 +1,83 @@
+package com.arnyminerz.escalaralcoiaicomtat.core.data
+
+import androidx.annotation.IntDef
+
+/**
+ * An object for holding Semantic Versioning version names.
+ *
+ * Follows the Semanting Versioning rules: https://semver.org/
+ * @author Arnau Mora
+ * @since 20220711
+ */
+data class SemVer(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+) {
+    companion object {
+        /**
+         * Initializes a new [SemVer] object from a string.
+         * The version must follow the Semantic Versioning (https://semver.org/): `MAJOR.MINOR.PATCH`.
+         *
+         * Example:
+         * * `1.5.6`
+         * @author Arnau Mora
+         * @since 20220711
+         * @param versionString The version string to parse.
+         * @throws IllegalArgumentException When the format of the input string is not valid.
+         * @throws IllegalStateException When a part of the version is not numeric.
+         */
+        @Throws(IllegalArgumentException::class, IllegalStateException::class)
+        fun fromString(versionString: String): SemVer {
+            val split = versionString
+                .split('.')
+                .takeIf { it.size == 3 }
+                ?: throw IllegalArgumentException("The format of the version is not valid: $versionString")
+
+            val major = split[0].toIntOrNull()
+                ?: throw IllegalStateException("Major version is not numeric: ${split[0]}")
+            val minor = split[1].toIntOrNull()
+                ?: throw IllegalStateException("Minor version is not numeric: ${split[1]}")
+            val patch = split[2].toIntOrNull()
+                ?: throw IllegalStateException("Patch version is not numeric: ${split[2]}")
+
+            return SemVer(major, minor, patch)
+        }
+
+        const val DIFF_EQUAL = 0
+        const val DIFF_PATCH = 1
+        const val DIFF_MINOR = 2
+        const val DIFF_MAJOR = 3
+
+        @Target(AnnotationTarget.TYPE)
+        @IntDef(DIFF_EQUAL, DIFF_MAJOR, DIFF_MINOR, DIFF_PATCH)
+        annotation class SemVerComparison
+    }
+
+    override fun toString(): String = "$major.$minor.$patch"
+
+    /**
+     * Compares two [SemVer]s and returns a [SemVerComparison] according to the differences. One of
+     * the following will happen:
+     * - If the versions are equal, [DIFF_EQUAL] is returned.
+     * - If the version change is of type patch, [DIFF_PATCH] is returned. This is intended for small
+     * fixes, and versions with patch changes should be compatible.
+     * - If the version change is of type minor, [DIFF_MINOR] is returned. This is intended for
+     * changes bigger than patch, but that might still be compatible, however, a warning is recommended.
+     * - If the version change is of type major, [DIFF_MAJOR] is returned. This is intended for big
+     * structural changes, and usually indicates incompatibility between versions. Caution is advised.
+     * @author Arnau Mora
+     * @since 20220711
+     * @param other The other version to compare against to.
+     * @return One of: [DIFF_EQUAL], [DIFF_PATCH], [DIFF_MINOR] or [DIFF_MAJOR].
+     */
+    fun compare(other: SemVer): @SemVerComparison Int =
+        if (major != other.major)
+            DIFF_MAJOR
+        else if (minor != other.minor)
+            DIFF_MINOR
+        else if (patch != other.patch)
+            DIFF_PATCH
+        else
+            DIFF_EQUAL
+}

--- a/core/src/main/java/com/arnyminerz/escalaralcoiaicomtat/core/shared/SharedConstants.kt
+++ b/core/src/main/java/com/arnyminerz/escalaralcoiaicomtat/core/shared/SharedConstants.kt
@@ -1,5 +1,7 @@
 package com.arnyminerz.escalaralcoiaicomtat.core.shared
 
+import com.arnyminerz.escalaralcoiaicomtat.core.data.SemVer
+
 const val APPLICATION_ID = "com.arnyminerz.escalaralcoiaicomtat"
 
 /**
@@ -75,7 +77,7 @@ const val PROFILE_IMAGE_SIZE_DEFAULT = 512L
  * @author Arnau Mora
  * @since 20220627
  */
-const val EXPECTED_SERVER_VERSION = "1.0.4"
+val EXPECTED_SERVER_VERSION = SemVer(1, 0, 5)
 
 /**
  * The maximum amount of days that will be allowed to the user not having updated the app

--- a/core/src/main/java/com/arnyminerz/escalaralcoiaicomtat/core/ui/isolated_screen/AppInfoWindow.kt
+++ b/core/src/main/java/com/arnyminerz/escalaralcoiaicomtat/core/ui/isolated_screen/AppInfoWindow.kt
@@ -13,7 +13,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,24 +26,29 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arnyminerz.escalaralcoiaicomtat.core.R
+import com.arnyminerz.escalaralcoiaicomtat.core.data.SemVer
+import com.arnyminerz.escalaralcoiaicomtat.core.shared.EXPECTED_SERVER_VERSION
 import com.arnyminerz.escalaralcoiaicomtat.core.utils.launch
+import com.arnyminerz.escalaralcoiaicomtat.core.utils.launchStore
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import compose.icons.FontAwesomeIcons
 import compose.icons.fontawesomeicons.Brands
 import compose.icons.fontawesomeicons.brands.Github
 
 @Composable
+@ExperimentalMaterial3Api
 fun ApplicationInfoWindow(
     @DrawableRes appIconResource: Int,
     appName: String,
     appBuild: Int,
     appVersion: String,
-    serverVersion: String,
+    serverVersion: SemVer,
     serverProduction: Boolean,
     githubLink: String,
 ) {
@@ -51,7 +60,7 @@ fun ApplicationInfoWindow(
             contentDescription = "",
             modifier = Modifier
                 .size(128.dp)
-                .padding(top = 128.dp)
+                .padding(top = 64.dp, bottom = 8.dp)
                 .align(Alignment.CenterHorizontally)
         )
         Text(
@@ -80,12 +89,20 @@ fun ApplicationInfoWindow(
                 style = MaterialTheme.typography.labelMedium,
             )
             Text(
-                serverVersion,
+                serverVersion.toString(),
                 modifier = Modifier
                     .padding(start = 4.dp),
                 fontStyle = if (serverProduction) FontStyle.Normal else FontStyle.Italic,
                 style = MaterialTheme.typography.labelMedium,
             )
+            if (!serverProduction)
+                Text(
+                    stringResource(R.string.pref_info_server_version_non_production),
+                    modifier = Modifier
+                        .padding(start = 2.dp),
+                    fontStyle = FontStyle.Italic,
+                    style = MaterialTheme.typography.labelMedium,
+                )
         }
         Button(
             onClick = {
@@ -116,18 +133,58 @@ fun ApplicationInfoWindow(
                 )
             }
         }
+
+        if (serverVersion != EXPECTED_SERVER_VERSION)
+            Card(
+                colors = CardDefaults.cardColors(
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.CenterHorizontally)
+                    .padding(vertical = 16.dp, horizontal = 16.dp),
+            ) {
+                Text(
+                    stringResource(R.string.pref_info_server_version_warning_title),
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                )
+                Text(
+                    stringResource(R.string.pref_info_server_version_warning_message)
+                        .format(
+                            EXPECTED_SERVER_VERSION.toString(),
+                            serverVersion.toString(),
+                        ),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                )
+                OutlinedButton(
+                    onClick = { context.launchStore() },
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .align(Alignment.End),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                ) {
+                    Text(stringResource(R.string.action_open_store))
+                }
+            }
     }
 }
 
 @Preview(showSystemUi = true)
 @Composable
+@ExperimentalMaterial3Api
 fun ApplicationInfoWindowPreview() {
     ApplicationInfoWindow(
         R.drawable.round_close_24,
         "Escalar Alcoià i Comtat",
         1,
         "1.0.0",
-        "1.0.4",
+        SemVer(1, 0, 4),
         false,
         "",
     )

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -189,6 +189,8 @@
     <string name="dialog_downloaded_partially_msg">Some children have been downloaded, but not "%s" completely. Do you want to download it complete?</string>
     <string name="dialog_uses_storage_msg">Uses: %s</string>
     <string name="dialog_share_title">Share</string>
+    <string name="dialog_server_version_title">Server Incompatible</string>
+    <string name="dialog_server_version_message">The server has been updated, and the version of the app you are using is not compatible. Please, get the latest one from the App Store.</string>
 
     <string name="downloads_sector_dialog_title">Sectors</string>
     <string name="downloads_delete_dialog_title">Are you sure?</string>
@@ -353,6 +355,9 @@
     <string name="pref_down_roaming_sum">Use roaming for downloads</string>
 
     <string name="pref_info_server_version">Server version: </string>
+    <string name="pref_info_server_version_non_production">(Non-production)</string>
+    <string name="pref_info_server_version_warning_title">Using Incompatible Version</string>
+    <string name="pref_info_server_version_warning_message">The version of the app you are using expects a server with version %s, but it\'s using %s. It should work correctly, but problems may occur, it\'s advised that you update the app to the latest version as soon as possible.</string>
 
     <string name="notification_channel_downloads_group_name">Downloads</string>
     <string name="notification_channel_download_progress_name">Download Progress</string>


### PR DESCRIPTION
Now server versions are parsed into Semantinc Versioning, and if the changes are of type "patch", they will be considered as compatible, and the app won't be blocked, however, a warning shows in the information screen.